### PR TITLE
Enable Dependabot for Git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: gitsubmodule
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "00:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Pulls dependencies from https://github.com/wiremock/api-template-library